### PR TITLE
Fix spelling: configuratoin -> configuration

### DIFF
--- a/src/soa/SessionAPI/Configuration/BrokerServicesConfiguration.cs
+++ b/src/soa/SessionAPI/Configuration/BrokerServicesConfiguration.cs
@@ -12,9 +12,9 @@ namespace Microsoft.Telepathy.Session.Configuration
     /// </summary>
     public sealed class BrokerServicesConfiguration : ConfigurationSection
     {
-        const string BrokerServiceAddressesConfiguratoinName = "brokerServiceAddresses";
+        const string BrokerServiceAddressesConfigurationName = "brokerServiceAddresses";
 
-        ConfigurationProperty brokerServiceAddresses = new ConfigurationProperty(BrokerServiceAddressesConfiguratoinName, typeof(BaseAddressElementCollection));
+        ConfigurationProperty brokerServiceAddresses = new ConfigurationProperty(BrokerServiceAddressesConfigurationName, typeof(BaseAddressElementCollection));
 
         ConfigurationPropertyCollection properties = new ConfigurationPropertyCollection();
 
@@ -47,7 +47,7 @@ namespace Microsoft.Telepathy.Session.Configuration
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Backward compatibility")]
         public Uri GetBrokerBaseAddress(string scheme)
         {
-            BaseAddressElementCollection baseAddresses = base[BrokerServiceAddressesConfiguratoinName] as BaseAddressElementCollection;
+            BaseAddressElementCollection baseAddresses = base[BrokerServiceAddressesConfigurationName] as BaseAddressElementCollection;
             return this.FindBaseAddress(baseAddresses, scheme);
         }
 

--- a/src/soa/SessionAPI/Configuration/HostConfiguration.cs
+++ b/src/soa/SessionAPI/Configuration/HostConfiguration.cs
@@ -11,8 +11,8 @@ namespace Microsoft.Telepathy.Session.Configuration
     /// </summary>
     public sealed class HostConfiguration : ConfigurationSection
     {
-        const string HostTypeConfiguratoinName = "hostType";
-        const string ExeFileConfiguratoinName = "exeFileName";
+        const string HostTypeConfigurationName = "hostType";
+        const string ExeFileConfigurationName = "exeFileName";
 
         /// <summary>
         /// Enumerable represents host types
@@ -42,8 +42,8 @@ namespace Microsoft.Telepathy.Session.Configuration
         /// </summary>
         public HostConfiguration()
         {
-            this.properties.Add(new ConfigurationProperty(HostTypeConfiguratoinName, typeof(HostType), HostType.Standard));
-            this.properties.Add(new ConfigurationProperty(ExeFileConfiguratoinName, typeof(string), String.Empty));
+            this.properties.Add(new ConfigurationProperty(HostTypeConfigurationName, typeof(HostType), HostType.Standard));
+            this.properties.Add(new ConfigurationProperty(ExeFileConfigurationName, typeof(string), String.Empty));
         }
 
         protected override ConfigurationPropertyCollection Properties
@@ -67,7 +67,7 @@ namespace Microsoft.Telepathy.Session.Configuration
                 if (this.Type == HostType.Standard)
                     return null;
 
-                return (string)this[ExeFileConfiguratoinName];
+                return (string)this[ExeFileConfigurationName];
             }
         }
 
@@ -81,7 +81,7 @@ namespace Microsoft.Telepathy.Session.Configuration
         {
             get
             {
-                return (HostType)this[HostTypeConfiguratoinName];
+                return (HostType)this[HostTypeConfigurationName];
             }
         }
 


### PR DESCRIPTION
I did not test any of these changes, but noticed a bunch of common mis-spellings.